### PR TITLE
Fix place parameters on a new line for very long member definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,12 @@ If you have a very long member definition, place the parameters on new lines and
 
 ```fsharp
 type C () =
-    member __.LongMethodWithLotsOfParameters(
-        aVeryLongType : AVeryLongTypeThatYouNeedToUse,
-        aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
-        aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse)
+    member __.LongMethodWithLotsOfParameters
+       (
+           aVeryLongType : AVeryLongTypeThatYouNeedToUse,
+           aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
+           aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
+       )
         =
         // ... the body of the method follows
 ```
@@ -145,10 +147,12 @@ type C () =
 This also applies to constructors:
 
 ```fsharp
-type C (
-    aVeryLongType : AVeryLongTypeThatYouNeedToUse,
-    aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
-    aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse)
+type C 
+    (
+        aVeryLongType : AVeryLongTypeThatYouNeedToUse,
+        aSecondVeryLongType : AVeryLongTypeThatYouNeedToUse,
+        aThirdVeryLongType : AVeryLongTypeThatYouNeedToUse
+    )
     =
     // ... the body of the class follows
 ```


### PR DESCRIPTION
Resolves #2