### PR TITLE
Clarify constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,6 +888,18 @@ let makeStreamReader x = new System.IO.StreamReader (path=x)
 let makeStreamReader x = new System.IO.StreamReader(path = x)
 ```
 
+### Formatting white space in constructors
+
+Use newlines and indent one scope, rather than indenting to the bracket, if using multiple lines:
+
+```fsharp
+let thing =
+    new Foobar(
+        argument1,
+        argument2
+    )
+```
+
 ## Formatting attributes
 
 [Attributes](../language-reference/attributes.md) are placed above a construct:


### PR DESCRIPTION
Sadly our "preferred" formatting is a syntax error due to offside indentation. That would be:

```fsharp
let thing = new Foobar(
    thing1,
    thing2
)
```

I've bitten the bullet and introduced another newline.

Aside: we are rather unclear on whether we want a space after the word `Foobar` here. I think *sometimes* it's a syntax error to insert a space.